### PR TITLE
Forgotten transactions

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -156,7 +156,7 @@ class Block {
         if (is_array($this->transactions) && !empty($this->transactions)) {
             //We go through all the transactions and add them to the block to be mined
             foreach ($this->transactions as $transaction) {
-                $data = $transaction->message();
+                $data .= $transaction->message();
             }
         }
 
@@ -259,7 +259,7 @@ class Block {
         $data = "";
         foreach ($this->transactions as $transaction) {
             if ($transaction->isValid())
-                $data = $transaction->message();
+                $data .= $transaction->message();
             else
                 return false;
         }


### PR DESCRIPTION
BEWARE: Do not commit as is, would be a breaking change, this needs hard fork.

Spotted a typo (2 places). As a result, only the last transaction hash was embedded in the message, not all block transactions.
Consequences to be asserted with care.

A compatibility patch can be done by first changing isValid() to test for both messages (all transactions or just the last one) when there is more than the coinbase transaction in the block.
Then, after a while, changing the mine() function.
This could allow to do it in a smooth way.